### PR TITLE
Initial codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @GuzmanHrz @alesanca @raulanatol
+* @GuzmanHrz @alesanca @raulanatol @GiovaMederos 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @GuzmanHrz @alesanca @raulanatol


### PR DESCRIPTION
He añadido un fichero CODEOWNERS usado para auto-asignar revisores en los repos.

Faltaría añadir al resto de integrantes del equipo.